### PR TITLE
Optimise easing library

### DIFF
--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -656,41 +656,41 @@ namespace JANOARG.Shared.Data.ChartInfo
 
             srEases[(int)EaseFunction.Linear] = new Ease
             {
-                In = (x) => x,
-                Out = (x) => x,
-                InOut = (x) => x
+                In = x => x,
+                Out = x => x,
+                InOut = x => x
             };
 
             srEases[(int)EaseFunction.Sine] = new Ease
             {
-                In = (x) => 1 - FastCos(x * _PI / 2),
-                Out = (x) => FastSin(x * _PI / 2),
-                InOut = (x) => (1 - FastCos(x * _PI)) / 2
+                In = x => 1 - FastCos(x * _PI / 2),
+                Out = x => FastSin(x * _PI / 2),
+                InOut = x => (1 - FastCos(x * _PI)) / 2
             };
 
             srEases[(int)EaseFunction.Quadratic] = new Ease
             {
-                In = (x) => x * x,
-                Out = (x) => 1 - ((1 - x) * (1 - x)),
-                InOut = (x) => x < 0.5f
+                In = x => x * x,
+                Out = x => 1 - ((1 - x) * (1 - x)),
+                InOut = x => x < 0.5f
                     ? 2 * x * x
                     : 1 - ((-2 * x + 2) * (-2 * x + 2)) / 2
             };
 
             srEases[(int)EaseFunction.Cubic] = new Ease
             {
-                In = (x) => x * x * x,
-                Out = (x) => 1 - ((1 - x) * (1 - x) * (1 - x)),
-                InOut = (x) => x < 0.5f
+                In = x => x * x * x,
+                Out = x => 1 - ((1 - x) * (1 - x) * (1 - x)),
+                InOut = x => x < 0.5f
                     ? 4 * x * x * x
                     : 1 - ((-2 * x + 2) * (-2 * x + 2) * (-2 * x + 2)) / 2
             };
 
             srEases[(int)EaseFunction.Quartic] = new Ease
             {
-                In = (x) => x * x * x * x,
-                Out = (x) => 1 - ((1 - x) * (1 - x) * (1 - x) * (1 - x)),
-                InOut = (x) => x < 0.5f
+                In = x => x * x * x * x,
+                Out = x => 1 - ((1 - x) * (1 - x) * (1 - x) * (1 - x)),
+                InOut = x => x < 0.5f
                     ? 8 * x * x * x * x
                     : 1 - ((-2 * x + 2) * (-2 * x + 2) * (-2 * x + 2) * (-2 * x + 2)) / 2
             };
@@ -699,22 +699,22 @@ namespace JANOARG.Shared.Data.ChartInfo
             // Maybe exponent is not ALU standard
             srEases[(int)EaseFunction.Quintic] = new Ease
             {
-                In = (x) => x * x * x * x * x,
-                Out = (x) => 1 - ((1 - x) * (1 - x) * (1 - x) * (1 - x) * (1 - x)),
-                InOut = (x) => x < 0.5f
+                In = x => x * x * x * x * x,
+                Out = x => 1 - ((1 - x) * (1 - x) * (1 - x) * (1 - x) * (1 - x)),
+                InOut = x => x < 0.5f
                     ? 16 * x * x * x * x * x
                     : 1 - ((-2 * x + 2) * (-2 * x + 2) * (-2 * x + 2) * (-2 * x + 2) * (-2 * x + 2)) / 2
             };
 
             srEases[(int)EaseFunction.Exponential] = new Ease
             {
-                In = (x) => x == 0
+                In = x => x == 0
                     ? 0
                     : FastPow(2, 10 * x - 10) - 0.0009765625f * (1 - x),
-                Out = (x) => FastApproximately(x, 1)
+                Out = x => FastApproximately(x, 1)
                     ? 1
                     : 1 - FastPow(2, -10 * x) + 0.0009765625f * x,
-                InOut = (x) => x == 0
+                InOut = x => x == 0
                     ? 0
                     : FastApproximately(x, 1)
                         ? 1
@@ -734,23 +734,23 @@ namespace JANOARG.Shared.Data.ChartInfo
 
             srEases[(int)EaseFunction.Back] = new Ease
             {
-                In = (x) => 2.70158f * x * x * x - _BACK_OVERSHOOT * x * x,
-                Out = (x) => 1 + 2.70158f * ((x - 1) * (x - 1) * (x - 1)) + _BACK_OVERSHOOT * ((x - 1) * (x - 1)),
-                InOut = (x) => x < 0.5f
+                In = x => 2.70158f * x * x * x - _BACK_OVERSHOOT * x * x,
+                Out = x => 1 + 2.70158f * ((x - 1) * (x - 1) * (x - 1)) + _BACK_OVERSHOOT * ((x - 1) * (x - 1)),
+                InOut = x => x < 0.5f
                     ? ((2 * x) * (2 * x)) * ((_BACK_SCALED_OVERSHOOT + 1) * 2 * x - _BACK_SCALED_OVERSHOOT) / 2
                     : (((2 * x - 2) * (2 * x - 2))* ((_BACK_SCALED_OVERSHOOT + 1) * (x * 2 - 2) + _BACK_SCALED_OVERSHOOT) + 2) / 2
             };
 
             srEases[(int)EaseFunction.Elastic] = new Ease
             {
-                In = (x) =>
+                In = x =>
                 {
                     if (x == 0) return 0;
                     if (FastApproximately(x, 1)) return 1;
 
                     return -FastPow(2, 10 * x - 10) * FastSin((x * 10 - _ELASTIC_IN_OFFSET) * _ELASTIC_PERIOD);
                 },
-                Out = (x) =>
+                Out = x =>
                 {
 
                     if (x == 0) return 0;
@@ -759,7 +759,7 @@ namespace JANOARG.Shared.Data.ChartInfo
 
                     return FastPow(2, -10 * x) * FastSin((x * 10 - _ELASTIC_OUT_OFFSET) * _ELASTIC_PERIOD) + 1;
                 },
-                InOut = (x) =>
+                InOut = x =>
                 {
 
                     if (x == 0) return 0;
@@ -773,8 +773,8 @@ namespace JANOARG.Shared.Data.ChartInfo
 
             srEases[(int)EaseFunction.Bounce] = new Ease
             {
-                In = (x) => 1 - Get(1 - x, EaseFunction.Bounce, EaseMode.Out),
-                Out = (x) =>
+                In = x => 1 - Get(1 - x, EaseFunction.Bounce, EaseMode.Out),
+                Out = x =>
                 {
 
                     if (x < 1 / _BOUNCE_THRESHOLD)
@@ -789,7 +789,7 @@ namespace JANOARG.Shared.Data.ChartInfo
 
                     return _BOUNCE_CONSTANT * (x -= 2.625f / _BOUNCE_THRESHOLD) * x + 0.984375f;
                 },
-                InOut = (x) => x < 0.5
+                InOut = x => x < 0.5
                     ? (1 - Get(1 - 2 * x, EaseFunction.Bounce, EaseMode.Out)) / 2
                     : (1 + Get(2 * x - 1, EaseFunction.Bounce, EaseMode.Out)) / 2
             };

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -144,11 +144,19 @@ namespace JANOARG.Shared.Data.ChartInfo
         }
         
         
-        public static float GetDelayed(float x, float delay, EaseFunction func, EaseMode mode, float scale = 1) =>
-            Get(x * scale - delay, func, mode);
-            
-        public static float GetMultiplied(float x, float scale, EaseFunction func, EaseMode mode) =>
-            Get(x * scale, func, mode);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        // ReSharper disable once MethodOverloadWithOptionalParameter
+        public static float Get(float x, EaseFunction func, EaseMode mode, float multiplier = 1, float delay = 0) =>
+            Get(x * multiplier - delay, func, mode);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float GetSharpened(float x, float p, EaseFunction func, EaseMode mode, float multiplier = 1, float delay = 0) =>
+            FastPow(Get(x * multiplier - delay, func, mode), p);
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float GetPreSharp(float x, float p, EaseFunction func, EaseMode mode, float multiplier = 1, float delay = 0) =>
+            Get(FastPow(x *  multiplier - delay, p), func, mode, multiplier);
+
         
 
         // We don't need DOTween, guys

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -29,6 +29,39 @@ namespace JANOARG.Shared.Data.ChartInfo
         Elastic,
         Bounce
     }
+    public class EaseUtils
+        {
+            public static float LerpTo(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+                (1 - Ease.Get(interpolator, easeFunc, mode)) * from + Ease.Get(interpolator, easeFunc, mode) * to;
+            
+            public static float LerpBy(float from, float delta, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+                (1 - Ease.Get(interpolator, easeFunc, mode)) * from + Ease.Get(interpolator, easeFunc, mode) * (from + delta);
+            
+            public static float ToZero(float from, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+                from * (1 - Ease.Get(interpolator, easeFunc, mode));
+            
+            public static float FromZero(float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+                to * Ease.Get(interpolator, easeFunc, mode);
+            
+            
+            // For predefined eases
+            
+            public static float LerpTo(float from, float to, float ease) =>
+                (1 - ease) * from + ease * to;
+            
+            public static float LerpBy(float from, float delta, float ease) =>
+                (1 - ease) * from + ease * (from + delta);
+            
+            public static float ToZero(float from, float ease) =>
+                from * (1 - ease);
+            
+            public static float FromZero(float to, float ease) =>
+                to * ease;
+            
+            public static float Snap(float from, float to, float ease) =>
+                (int)ease == 1 ? to : from;
+            
+        }
 
     [Serializable]
     public class Ease
@@ -50,42 +83,13 @@ namespace JANOARG.Shared.Data.ChartInfo
                 _ => sEases[(int)easeFunc].InOut(x)
             };
         }
-
-        public class Presets
-        {
-            public static float GetDelayedEase(float x, float delay, float scale, EaseFunction func, EaseMode mode) =>
-                Ease.Get(Mathf.Clamp01(x * scale - delay), func, mode);
+        
+        public static float GetDelayedEase(float x, float delay, EaseFunction func, EaseMode mode, float scale = 1) =>
+            Ease.Get(Mathf.Clamp01(x * scale - delay), func, mode);
             
-            public static float LerpTo(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
-                (1 - Get(interpolator, easeFunc, mode)) * from + Get(interpolator, easeFunc, mode) * to;
-            
-            public static float ToZero(float from, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
-                from * (1 - Get(interpolator, easeFunc, mode));
-            
-            public static float FromZero(float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
-                to * Get(interpolator, easeFunc, mode);
-            
-            public static float SharpDropEase(float interpolator, EaseFunction easeFunc, EaseMode mode) =>
-                (1 - Get(interpolator, easeFunc, mode)) * (1 - Get(interpolator, easeFunc, mode));
-            
-            public static float Snap(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
-                (int)interpolator == 1 ? to : from;
-            
-            // For predefined eases
-            
-            public static float LerpTo(float from, float to, float ease) =>
-                (1 - ease) * from + ease * to;
-            
-            public static float ToZero(float from, float ease) =>
-                from * (1 - ease);
-            
-            public static float FromZero(float to, float ease) =>
-                to * ease;
-            
-            public static float SharpDropEase(float ease) =>
-                (1 - ease) * (1 - ease);
-            
-        }
+        public static float GetMultipliedEase(float x, float scale, EaseFunction func, EaseMode mode) =>
+            Ease.Get(Mathf.Clamp01(x * scale), func, mode);
+        
 
         // We don't need DOTween, guys
         public static IEnumerator Animate(float duration, Action<float> callback)

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -185,7 +185,7 @@ namespace JANOARG.Shared.Data.ChartInfo
 
         /// <summary>
         /// Animates with easing, with support for shortcuts to ease parameters for callback.
-        /// Useful for creating multiple easings with similar parameters.
+        /// Useful for creating multiple easings with similar parameters, with declarative syntax.
         /// </summary>
         /// <param name="duration">Total animation time in seconds</param>
         /// <param name="easeFunc">Easing function type</param>

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -29,39 +29,41 @@ namespace JANOARG.Shared.Data.ChartInfo
         Elastic,
         Bounce
     }
-    public class EaseUtils
-        {
-            public static float LerpTo(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
-                (1 - Ease.Get(interpolator, easeFunc, mode)) * from + Ease.Get(interpolator, easeFunc, mode) * to;
-            
-            public static float LerpBy(float from, float delta, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
-                (1 - Ease.Get(interpolator, easeFunc, mode)) * from + Ease.Get(interpolator, easeFunc, mode) * (from + delta);
-            
-            public static float ToZero(float from, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
-                from * (1 - Ease.Get(interpolator, easeFunc, mode));
-            
-            public static float FromZero(float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
-                to * Ease.Get(interpolator, easeFunc, mode);
-            
-            
-            // For predefined eases
-            
-            public static float LerpTo(float from, float to, float ease) =>
-                (1 - ease) * from + ease * to;
-            
-            public static float LerpBy(float from, float delta, float ease) =>
-                (1 - ease) * from + ease * (from + delta);
-            
-            public static float ToZero(float from, float ease) =>
-                from * (1 - ease);
-            
-            public static float FromZero(float to, float ease) =>
-                to * ease;
-            
-            public static float Snap(float from, float to, float ease) =>
-                (int)ease == 1 ? to : from;
-            
-        }
+    
+    [Serializable]
+    public static class EaseUtils
+    {
+        public static float LerpTo(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+            (1 - Ease.Get(interpolator, easeFunc, mode)) * from + Ease.Get(interpolator, easeFunc, mode) * to;
+        
+        public static float LerpBy(float from, float delta, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+            (1 - Ease.Get(interpolator, easeFunc, mode)) * from + Ease.Get(interpolator, easeFunc, mode) * (from + delta);
+        
+        public static float ToZero(float from, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+            from * (1 - Ease.Get(interpolator, easeFunc, mode));
+        
+        public static float FromZero(float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+            to * Ease.Get(interpolator, easeFunc, mode);
+        
+        
+        // For predefined eases
+        
+        public static float LerpTo(float from, float to, float ease) =>
+            (1 - ease) * from + ease * to;
+        
+        public static float LerpBy(float from, float delta, float ease) =>
+            (1 - ease) * from + ease * (from + delta);
+        
+        public static float ToZero(float from, float ease) =>
+            from * (1 - ease);
+        
+        public static float FromZero(float to, float ease) =>
+            to * ease;
+        
+        public static float Snap(float from, float to, float ease) =>
+            (int)ease == 1 ? to : from;
+        
+    }
 
     [Serializable]
     public class Ease

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using TMPro;
 using UnityEngine;
 
@@ -61,6 +62,44 @@ namespace JANOARG.Shared.Data.ChartInfo
 
             callback(1);
         }
+
+        public static IEnumerator Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode> callback)
+        {
+            for (float a = 0; a < 1; a += Time.deltaTime / duration)
+            {
+                callback(a, easeFunc, mode);
+
+                yield return null;
+            }
+
+            callback(1, easeFunc, mode);
+        }
+        
+        // Task Async alternative
+        public static async Task AnimateTask(float duration, Action<float> callback)
+        {
+            for (float a = 0; a < 1; a += Time.deltaTime / duration)
+            {
+                callback(a);
+                await Task.Yield();
+            }
+
+            callback(1);
+        }
+
+        public static async Task AnimateTask(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode> callback)
+        {
+            for (float a = 0; a < 1; a += Time.deltaTime / duration)
+            {
+                callback(a, easeFunc, mode);
+
+                await Task.Yield();
+            }
+
+            callback(1, easeFunc, mode);
+        }
+        
+        
 
         public static IEnumerator AnimateText(TMP_Text text, float duration, float xOffset, Action<TMP_CharacterInfo, float> letterCallback)
         {

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -115,8 +114,8 @@ namespace JANOARG.Shared.Data.ChartInfo
         public Func<float, float> Out;
         public Func<float, float> InOut;
 
-        private static bool s_cancelRequested = false;
-        private static bool s_forceCancelRequested = false;
+        private static bool s_cancelRequested;
+        private static bool s_forceCancelRequested;
         
         /// <summary>
         /// Properly finish the current Animate loop by skipping to callback(1).
@@ -428,7 +427,7 @@ namespace JANOARG.Shared.Data.ChartInfo
 
         // Fast approximate equality check
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool FastApproximately(float a, float b = 1f)
+        public static bool FastApproximately(float a, float b)
         {
             // For our easing functions, we typically compare with 1 or 0
             // Using subtraction is faster than Mathf.Abs for this case

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -97,6 +97,21 @@ namespace JANOARG.Shared.Data.ChartInfo
         public Func<float, float> Out;
         public Func<float, float> InOut;
 
+        private static bool s_cancelRequested = false;
+        private static bool s_forceCancelRequested = false;
+        
+        /// <summary>
+        /// Properly finish the current Animate loop by skipping to callback(1).
+        /// Recommended to use this over StopCoroutine.
+        /// </summary>
+        public static void Skip(bool force = false)
+        {
+            s_cancelRequested = true;
+            
+            if (force) s_forceCancelRequested = true;
+            
+        }
+
         public static float Get(float x, EaseFunction easeFunc, EaseMode mode)
         {
             //Ease funcs = sEases[(int)easeFunc];
@@ -123,9 +138,21 @@ namespace JANOARG.Shared.Data.ChartInfo
         {
             for (float a = 0; a < 1; a += Time.deltaTime / duration)
             {
+                if (s_cancelRequested)
+                {
+                    s_cancelRequested = false;
+                    break;
+                }
+                
                 callback(a);
 
                 yield return null;
+            }
+
+            if (s_forceCancelRequested)
+            {
+                s_forceCancelRequested = false;
+                yield break;
             }
 
             callback(1);
@@ -135,11 +162,22 @@ namespace JANOARG.Shared.Data.ChartInfo
         {
             for (float a = 0; a < 1; a += Time.deltaTime / duration)
             {
+                if (s_cancelRequested)
+                {
+                    s_cancelRequested = false;
+                    break;
+                }
+                
                 callback(a, easeFunc, mode);
 
                 yield return null;
             }
 
+            if (s_forceCancelRequested)
+            {
+                s_forceCancelRequested = false;
+                yield break;
+            }
             callback(1, easeFunc, mode);
         }
         

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -70,6 +70,21 @@ namespace JANOARG.Shared.Data.ChartInfo
             
             public static float Snap(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
                 (int)interpolator == 1 ? to : from;
+            
+            // For predefined eases
+            
+            public static float LerpTo(float from, float to, float ease) =>
+                (1 - ease) * from + ease * to;
+            
+            public static float ToZero(float from, float ease) =>
+                from * (1 - ease);
+            
+            public static float FromZero(float to, float ease) =>
+                to * ease;
+            
+            public static float SharpDropEase(float ease) =>
+                (1 - ease) * (1 - ease);
+            
         }
 
         // We don't need DOTween, guys

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -50,6 +50,27 @@ namespace JANOARG.Shared.Data.ChartInfo
             };
         }
 
+        public class Presets
+        {
+            public static float GetDelayedEase(float x, float delay, float scale, EaseFunction func, EaseMode mode) =>
+                Ease.Get(Mathf.Clamp01(x * scale - delay), func, mode);
+            
+            public static float LerpTo(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+                (1 - Get(interpolator, easeFunc, mode)) * from + Get(interpolator, easeFunc, mode) * to;
+            
+            public static float ToZero(float from, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+                from * (1 - Get(interpolator, easeFunc, mode));
+            
+            public static float FromZero(float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+                to * Get(interpolator, easeFunc, mode);
+            
+            public static float SharpDropEase(float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+                (1 - Get(interpolator, easeFunc, mode)) * (1 - Get(interpolator, easeFunc, mode));
+            
+            public static float Snap(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+                (int)interpolator == 1 ? to : from;
+        }
+
         // We don't need DOTween, guys
         public static IEnumerator Animate(float duration, Action<float> callback)
         {

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -578,12 +578,63 @@ namespace JANOARG.Shared.Data.ChartInfo
             return FastPow2(exponent);
         }
         
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float PseudoFastSqrt(float x) => FastPow(x, 0.5f);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float FastSqrt(float x) =>
-            x < 0 
-                ? throw new InvalidOperationException("Cannot take square root of negative number") 
-                : FastPow(x, 0.5f);
+        public static float FastSqrt(float x, bool precision = false)
+        {
+            // Testing
+            //return Mathf.Sqrt(x);
+            
+            Debug.Assert(x >= 0f, "FastSqrt(float): input must be non-negative.");
+
+            if (x == 0f) return 0f;
+
+            float y = x;
+            
+            // 1 / derivative of y^2 - x
+            const float COEFFICIENT = 0.5f;
+
+            // Single Newton-Raphson iteration: fast approximation of sqrt(x)
+            y = COEFFICIENT * (y + x / y);
+
+            // Optional second iteration for slightly higher accuracy.
+            // More iterations would exceed float precision and provide negligible benefit.
+            if (precision)
+                y = COEFFICIENT * (y + x / y);
+
+            y = y > 1 ? 1 : y;
+            y = y < 0 ? 0 : y;
+            
+            return y; 
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double FastSqrt(double x, bool precision = false)
+        {
+            Debug.Assert(x >= 0.0, "FastSqrt(double): input must be non-negative.");
+
+            if (x == 0.0) return 0.0;
+
+            double y = x;
+            
+            // 1 / derivative of y^2 - x
+            const double COEFFICIENT = 0.5;
+
+            y = COEFFICIENT * (y + x / y);
+
+            // Optional three extra iterations for full double-precision accuracy
+            if (precision)
+            {
+                y = COEFFICIENT * (y + x / y);
+                y = COEFFICIENT * (y + x / y);
+            }
+
+            return y;
+        }
+
 
         // Fast approximate equality check
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -223,11 +223,9 @@ namespace JANOARG.Shared.Data.ChartInfo
             return y;
         }
             
-        private static float FastCos(float x)
-        {
+        private static float FastCos(float x) =>
             // Cos in a nutshell: Sine, just translated back by 90 degrees (but we're using rad so yeah)
-            return FastSin(_PI_HALF - x);
-        }
+            FastSin(_PI_HALF - x);
 
         // Fast power approximation for base 2
         private static float FastPow2(float p)
@@ -246,12 +244,15 @@ namespace JANOARG.Shared.Data.ChartInfo
         }
 
         // Fast power function for any base
-        private static float FastPow(float a, float b)
-        {
+        private static float FastPow(float a, float b) =>
             // Logarithm shouldn't be costly, I think?
-            return FastPow2(b * Mathf.Log(a, 2));
-        }
-        
+            FastPow2(b * Mathf.Log(a, 2));
+
+        private static float FastSqrt(float x) =>
+            x < 0 
+                ? throw new InvalidOperationException("Cannot take square root of negative number") 
+                : FastPow(x, 0.5f);
+
         // Fast approximate equality check
         private static bool FastApproximately(float a, float b = 1f)
         {
@@ -340,11 +341,11 @@ namespace JANOARG.Shared.Data.ChartInfo
 
             sEases[(int)EaseFunction.Circle] = new Ease
             {
-                In = (x) => 1 - Mathf.Sqrt(1 - (x * x)),
-                Out = (x) => Mathf.Sqrt(1 - ((x - 1) * (x - 1))),
+                In = (x) => 1 - FastSqrt(1 - (x * x)),
+                Out = (x) => FastSqrt(1 - ((x - 1) * (x - 1))),
                 InOut = (x) => x < 0.5
-                    ? (1 - Mathf.Sqrt(1 - ((2 * x) * (2 * x)))) / 2
-                    : (Mathf.Sqrt(1 - ((-2 * x + 2) * (-2 * x + 2))) + 1) / 2
+                    ? (1 - FastSqrt(1 - ((2 * x) * (2 * x)))) / 2
+                    : (FastSqrt(1 - ((-2 * x + 2) * (-2 * x + 2))) + 1) / 2
             };
 
             sEases[(int)EaseFunction.Back] = new Ease

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -398,8 +398,12 @@ namespace JANOARG.Shared.Data.ChartInfo
         // Fast power approximation for base 2
         public static float FastPow2(float p)
         {
-            float offset = (p < 0) ? 1.0f : 0.0f;
-            float clipp = (p < -126) ? -126.0f : p;
+            float offset = (p < 0) 
+                ? 1.0f : 0.0f;
+            
+            float clipp = (p < -126) 
+                ? -126.0f : p;
+            
             int w = (int)clipp;
             float z = clipp - w + offset;
         
@@ -432,29 +436,29 @@ namespace JANOARG.Shared.Data.ChartInfo
             return diff is < _EPSILON and > -_EPSILON;
         }
         
-        public static Ease[] sEases;
+        public static readonly Ease[] srEases;
 
         // We will reduce as much external calls as possible,
         // given this library is being called ~3000+ times per frame
         static Ease()
         {
-            sEases = new Ease[Enum.GetValues(typeof(EaseFunction)).Length];
+            srEases = new Ease[Enum.GetValues(typeof(EaseFunction)).Length];
 
-            sEases[(int)EaseFunction.Linear] = new Ease
+            srEases[(int)EaseFunction.Linear] = new Ease
             {
                 In = (x) => x,
                 Out = (x) => x,
                 InOut = (x) => x
             };
 
-            sEases[(int)EaseFunction.Sine] = new Ease
+            srEases[(int)EaseFunction.Sine] = new Ease
             {
                 In = (x) => 1 - FastCos(x * _PI / 2),
                 Out = (x) => FastSin(x * _PI / 2),
                 InOut = (x) => (1 - FastCos(x * _PI)) / 2
             };
 
-            sEases[(int)EaseFunction.Quadratic] = new Ease
+            srEases[(int)EaseFunction.Quadratic] = new Ease
             {
                 In = (x) => x * x,
                 Out = (x) => 1 - ((1 - x) * (1 - x)),
@@ -463,7 +467,7 @@ namespace JANOARG.Shared.Data.ChartInfo
                     : 1 - ((-2 * x + 2) * (-2 * x + 2)) / 2
             };
 
-            sEases[(int)EaseFunction.Cubic] = new Ease
+            srEases[(int)EaseFunction.Cubic] = new Ease
             {
                 In = (x) => x * x * x,
                 Out = (x) => 1 - ((1 - x) * (1 - x) * (1 - x)),
@@ -472,7 +476,7 @@ namespace JANOARG.Shared.Data.ChartInfo
                     : 1 - ((-2 * x + 2) * (-2 * x + 2) * (-2 * x + 2)) / 2
             };
 
-            sEases[(int)EaseFunction.Quartic] = new Ease
+            srEases[(int)EaseFunction.Quartic] = new Ease
             {
                 In = (x) => x * x * x * x,
                 Out = (x) => 1 - ((1 - x) * (1 - x) * (1 - x) * (1 - x)),
@@ -483,7 +487,7 @@ namespace JANOARG.Shared.Data.ChartInfo
 
             // For fuck's sake, why do C# not have an exponent operator??
             // Maybe exponent is not ALU standard
-            sEases[(int)EaseFunction.Quintic] = new Ease
+            srEases[(int)EaseFunction.Quintic] = new Ease
             {
                 In = (x) => x * x * x * x * x,
                 Out = (x) => 1 - ((1 - x) * (1 - x) * (1 - x) * (1 - x) * (1 - x)),
@@ -492,7 +496,7 @@ namespace JANOARG.Shared.Data.ChartInfo
                     : 1 - ((-2 * x + 2) * (-2 * x + 2) * (-2 * x + 2) * (-2 * x + 2) * (-2 * x + 2)) / 2
             };
 
-            sEases[(int)EaseFunction.Exponential] = new Ease
+            srEases[(int)EaseFunction.Exponential] = new Ease
             {
                 In = (x) => x == 0
                     ? 0
@@ -509,7 +513,7 @@ namespace JANOARG.Shared.Data.ChartInfo
                             : (2 - FastPow(2, -20 * x + 10)) / 2 + 0.0009765625f * x
             };
 
-            sEases[(int)EaseFunction.Circle] = new Ease
+            srEases[(int)EaseFunction.Circle] = new Ease
             {
                 In = (x) => 1 - FastSqrt(1 - (x * x)),
                 Out = (x) => FastSqrt(1 - ((x - 1) * (x - 1))),
@@ -518,7 +522,7 @@ namespace JANOARG.Shared.Data.ChartInfo
                     : (FastSqrt(1 - ((-2 * x + 2) * (-2 * x + 2))) + 1) / 2
             };
 
-            sEases[(int)EaseFunction.Back] = new Ease
+            srEases[(int)EaseFunction.Back] = new Ease
             {
                 In = (x) => 2.70158f * x * x * x - _BACK_OVERSHOOT * x * x,
                 Out = (x) => 1 + 2.70158f * ((x - 1) * (x - 1) * (x - 1)) + _BACK_OVERSHOOT * ((x - 1) * (x - 1)),
@@ -527,7 +531,7 @@ namespace JANOARG.Shared.Data.ChartInfo
                     : (((2 * x - 2) * (2 * x - 2))* ((_BACK_SCALED_OVERSHOOT + 1) * (x * 2 - 2) + _BACK_SCALED_OVERSHOOT) + 2) / 2
             };
 
-            sEases[(int)EaseFunction.Elastic] = new Ease
+            srEases[(int)EaseFunction.Elastic] = new Ease
             {
                 In = (x) =>
                 {
@@ -557,7 +561,7 @@ namespace JANOARG.Shared.Data.ChartInfo
                 }
             };
 
-            sEases[(int)EaseFunction.Bounce] = new Ease
+            srEases[(int)EaseFunction.Bounce] = new Ease
             {
                 In = (x) => 1 - Get(1 - x, EaseFunction.Bounce, EaseMode.Out),
                 Out = (x) =>

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -197,6 +197,74 @@ namespace JANOARG.Shared.Data.ChartInfo
             callback(1, easeFunc, mode);
         }
         
+        /// <summary>
+        /// Animates with easing, automatically calculating eased value and providing all parameters.
+        /// Most comprehensive version - gives access to raw progress, ease parameters shortcuts, and pre-calculated eased value.
+        /// </summary>
+        /// <param name="duration">Total animation time in seconds</param>
+        /// <param name="easeFunc">Easing function type</param>
+        /// <param name="mode">Easing mode (In/Out/InOut)</param>
+        /// <param name="callback">Action receiving (progress, easeFunc, mode, easedValue) each frame</param>
+        public static IEnumerator Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode, float> callback)
+        {
+            float ease;
+            for (float a = 0; a < 1; a += Time.deltaTime / duration)
+            {
+                if (s_cancelRequested)
+                {
+                    s_cancelRequested = false;
+                    break;
+                }
+                
+                ease = Get(a, easeFunc, mode);
+                callback(a, easeFunc, mode, ease);
+
+                yield return null;
+            }
+
+            if (s_forceCancelRequested)
+            {
+                s_forceCancelRequested = false;
+                yield break;
+            }
+            ease = Get(1, easeFunc, mode);
+            callback(1, easeFunc, mode, ease);
+        }
+        
+        /// <summary>
+        /// Animates with easing, automatically calculating, and providing only the eased value to callback.
+        /// Simplest eased animation - callback receives only the pre-calculated eased progress (0 to 1).
+        /// </summary>
+        /// <param name="duration">Total animation time in seconds</param>
+        /// <param name="easeFunc">Easing function type</param>
+        /// <param name="mode">Easing mode (In/Out/InOut)</param>
+        /// <param name="callback">Action receiving eased progress value (0 to 1) each frame</param>
+        public static IEnumerator Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float> callback)
+        {
+            float ease;
+            for (float a = 0; a < 1; a += Time.deltaTime / duration)
+            {
+                if (s_cancelRequested)
+                {
+                    s_cancelRequested = false;
+                    break;
+                }
+                
+                ease = Get(a, easeFunc, mode);
+                callback(ease);
+
+                yield return null;
+            }
+
+            if (s_forceCancelRequested)
+            {
+                s_forceCancelRequested = false;
+                yield break;
+            }
+            ease = Get(1, easeFunc, mode);
+            callback(ease);
+        }
+        
         // Task Async alternative
         public static async Task AnimateTask(float duration, Action<float> callback, CancellationToken token = default)
         {

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -135,6 +135,13 @@ namespace JANOARG.Shared.Data.ChartInfo
         
 
         // We don't need DOTween, guys
+        
+        /// <summary>
+        /// Animates a value from 0 to 1 over specified duration, invoking callback each frame with linear progress.
+        /// Supports cancellation via Ease.Skip
+        /// </summary>
+        /// <param name="duration">Total animation time in seconds</param>
+        /// <param name="callback">Action receiving linear progress (0 to 1) each frame</param>
         public static IEnumerator Animate(float duration, Action<float> callback)
         {
             for (float a = 0; a < 1; a += Time.deltaTime / duration)
@@ -159,6 +166,14 @@ namespace JANOARG.Shared.Data.ChartInfo
             callback(1);
         }
 
+        /// <summary>
+        /// Animates with easing, with support for shortcuts to ease parameters for callback.
+        /// Useful for creating multiple easings with similar parameters.
+        /// </summary>
+        /// <param name="duration">Total animation time in seconds</param>
+        /// <param name="easeFunc">Easing function type</param>
+        /// <param name="mode">Easing mode (In/Out/InOut)</param>
+        /// <param name="callback">Action receiving (progress, easeFunc, mode) each frame</param>
         public static IEnumerator Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode> callback)
         {
             for (float a = 0; a < 1; a += Time.deltaTime / duration)

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -45,6 +45,12 @@ namespace JANOARG.Shared.Data.ChartInfo
         public static float FromZero(float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             to * Ease.Get(interpolator, easeFunc, mode);
         
+        public static float BlastIn(float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+            to / Ease.Get(interpolator, easeFunc, mode);
+
+        public static float BlastOut(float from, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+            from / (1 - Ease.Get(interpolator, easeFunc, mode));
+        
         
         // For predefined eases
         
@@ -62,6 +68,12 @@ namespace JANOARG.Shared.Data.ChartInfo
         
         public static float Snap(float from, float to, float ease) =>
             (int)ease == 1 ? to : from;
+        
+        public static float BlastIn(float to, float ease) =>
+            to / ease;
+        
+        public static float BlastOut(float from, float ease) =>
+            from / (1 - ease);
         
     }
 

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -99,10 +99,10 @@ namespace JANOARG.Shared.Data.ChartInfo
         }
         
         public static float GetDelayedEase(float x, float delay, EaseFunction func, EaseMode mode, float scale = 1) =>
-            Ease.Get(Mathf.Clamp01(x * scale - delay), func, mode);
+            Ease.Get(x * scale - delay, func, mode);
             
         public static float GetMultipliedEase(float x, float scale, EaseFunction func, EaseMode mode) =>
-            Ease.Get(Mathf.Clamp01(x * scale), func, mode);
+            Ease.Get(x * scale, func, mode);
         
 
         // We don't need DOTween, guys

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -235,8 +235,10 @@ namespace JANOARG.Shared.Data.ChartInfo
             int w = (int)clipp;
             float z = clipp - w + offset;
         
-            // This is a approximation of 2^z in range [0,1)
-            // Using bit shifting of constants I cannot comprehend (it's the same kind of workaround to do division in assembly)
+            // Approximation of 2^z for z in [0,1]
+            // Uses a fast bit-level hack by manipulating the float’s exponent bits directly.
+            // The constants are empirically tuned to produce a close approximation without calling Mathf.Pow.
+            // Equivalent to “fast 2^z” in older graphics/audio routines or assembly tricks.
             return BitConverter.Int32BitsToSingle(
                 (int)((1 << 23) * (clipp + 121.2740575f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z)));
         }

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using TMPro;
@@ -33,58 +34,74 @@ namespace JANOARG.Shared.Data.ChartInfo
     [Serializable]
     public static class EaseUtils
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float LerpTo(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             (1 - Ease.Get(interpolator, easeFunc, mode)) * from + Ease.Get(interpolator, easeFunc, mode) * to;
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float InverseLerpTo(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             Ease.Get(interpolator, easeFunc, mode) * from + (1 - Ease.Get(interpolator, easeFunc, mode)) * to;
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float LerpBy(float from, float delta, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             (1 - Ease.Get(interpolator, easeFunc, mode)) * from + Ease.Get(interpolator, easeFunc, mode) * (from + delta);
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float InverseLerpBy(float from, float delta, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             from + delta * (1 - Ease.Get(interpolator, easeFunc, mode));
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float ToZero(float from, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             from * (1 - Ease.Get(interpolator, easeFunc, mode));
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float FromZero(float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             to * Ease.Get(interpolator, easeFunc, mode);
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float BlastIn(float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             to / Ease.Get(interpolator, easeFunc, mode);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float BlastOut(float from, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             from / (1 - Ease.Get(interpolator, easeFunc, mode));
         
         
         // For predefined eases
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float LerpTo(float from, float to, float ease) =>
             (1 - ease) * from + ease * to;
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float InverseLerpTo(float from, float to, float ease) =>
             ease * from + (1 - ease) * to;
 
-        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float LerpBy(float from, float delta, float ease) =>
             (1 - ease) * from + ease * (from + delta);
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float InverseLerpBy(float from, float delta, float ease) =>
             from + delta * (1 - ease);
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float ToZero(float from, float ease) =>
             from * (1 - ease);
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float FromZero(float to, float ease) =>
             to * ease;
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Snap(float from, float to, float ease) =>
             (int)ease == 1 ? to : from;
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float BlastIn(float to, float ease) =>
             to / ease;
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float BlastOut(float from, float ease) =>
             from / (1 - ease);
         
@@ -370,6 +387,7 @@ namespace JANOARG.Shared.Data.ChartInfo
             return y;
         }
             
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float FastCos(float x) =>
             // Cos in a nutshell: Sine, just translated back by 90 degrees (but we're using rad so yeah)
             FastSin(_PI_HALF - x);
@@ -395,12 +413,14 @@ namespace JANOARG.Shared.Data.ChartInfo
             // Logarithm shouldn't be costly, I think?
             FastPow2(b * Mathf.Log(a, 2));
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float FastSqrt(float x) =>
             x < 0 
                 ? throw new InvalidOperationException("Cannot take square root of negative number") 
                 : FastPow(x, 0.5f);
 
         // Fast approximate equality check
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool FastApproximately(float a, float b = 1f)
         {
             // For our easing functions, we typically compare with 1 or 0

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using TMPro;
 using UnityEngine;
@@ -97,23 +98,23 @@ namespace JANOARG.Shared.Data.ChartInfo
         }
         
         // Task Async alternative
-        public static async Task AnimateTask(float duration, Action<float> callback)
+        public static async Task AnimateTask(float duration, Action<float> callback, CancellationToken token = default)
         {
             float a = 0;
-            while (a < 1)
+            while (a < 1 && !token.IsCancellationRequested)
             {
                 callback(a);
-                await Task.Yield(); // return next frame
+                await Task.Yield();
                 a += Time.deltaTime / duration;
             }
             callback(1f);
         }
+        
 
-
-        public static async Task AnimateTask(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode> callback)
+        public static async Task AnimateTask(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode> callback, CancellationToken token = default)
         {
             float a = 0f;
-            while (a < 1)
+            while (a < 1 && !token.IsCancellationRequested)
             {
                 callback(a, easeFunc, mode);
                 await Task.Yield();

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -143,9 +143,9 @@ namespace JANOARG.Shared.Data.ChartInfo
             // No need to cache on static readonly arrays
             return mode switch
             {
-                EaseMode.In => srEases[(int)easeFunc].In(x),
+                EaseMode.In  => srEases[(int)easeFunc].In(x),
                 EaseMode.Out => srEases[(int)easeFunc].Out(x), 
-                _ => srEases[(int)easeFunc].InOut(x)
+                _            => srEases[(int)easeFunc].InOut(x)
             };
         }
 

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -36,8 +36,14 @@ namespace JANOARG.Shared.Data.ChartInfo
         public static float LerpTo(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             (1 - Ease.Get(interpolator, easeFunc, mode)) * from + Ease.Get(interpolator, easeFunc, mode) * to;
         
+        public static float InverseLerpTo(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+            Ease.Get(interpolator, easeFunc, mode) * from + (1 - Ease.Get(interpolator, easeFunc, mode)) * to;
+        
         public static float LerpBy(float from, float delta, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             (1 - Ease.Get(interpolator, easeFunc, mode)) * from + Ease.Get(interpolator, easeFunc, mode) * (from + delta);
+        
+        public static float InverseLerpBy(float from, float delta, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
+            from + delta * (1 - Ease.Get(interpolator, easeFunc, mode));
         
         public static float ToZero(float from, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             from * (1 - Ease.Get(interpolator, easeFunc, mode));
@@ -57,8 +63,15 @@ namespace JANOARG.Shared.Data.ChartInfo
         public static float LerpTo(float from, float to, float ease) =>
             (1 - ease) * from + ease * to;
         
+        public static float InverseLerpTo(float from, float to, float ease) =>
+            ease * from + (1 - ease) * to;
+
+        
         public static float LerpBy(float from, float delta, float ease) =>
             (1 - ease) * from + ease * (from + delta);
+        
+        public static float InverseLerpBy(float from, float delta, float ease) =>
+            from + delta * (1 - ease);
         
         public static float ToZero(float from, float ease) =>
             from * (1 - ease);
@@ -221,7 +234,7 @@ namespace JANOARG.Shared.Data.ChartInfo
         private const float _BOUNCE_CONSTANT  = 7.5625f;
         private const float _BOUNCE_THRESHOLD = 2.75f;
         
-        private static float FastSin(float x)
+        public static float FastSin(float x)
         {
             const float B = 4f / _PI;
             const float C = -4f / (_PI * _PI);
@@ -235,12 +248,12 @@ namespace JANOARG.Shared.Data.ChartInfo
             return y;
         }
             
-        private static float FastCos(float x) =>
+        public static float FastCos(float x) =>
             // Cos in a nutshell: Sine, just translated back by 90 degrees (but we're using rad so yeah)
             FastSin(_PI_HALF - x);
 
         // Fast power approximation for base 2
-        private static float FastPow2(float p)
+        public static float FastPow2(float p)
         {
             float offset = (p < 0) ? 1.0f : 0.0f;
             float clipp = (p < -126) ? -126.0f : p;
@@ -256,17 +269,17 @@ namespace JANOARG.Shared.Data.ChartInfo
         }
 
         // Fast power function for any base
-        private static float FastPow(float a, float b) =>
+        public static float FastPow(float a, float b) =>
             // Logarithm shouldn't be costly, I think?
             FastPow2(b * Mathf.Log(a, 2));
 
-        private static float FastSqrt(float x) =>
+        public static float FastSqrt(float x) =>
             x < 0 
                 ? throw new InvalidOperationException("Cannot take square root of negative number") 
                 : FastPow(x, 0.5f);
 
         // Fast approximate equality check
-        private static bool FastApproximately(float a, float b = 1f)
+        public static bool FastApproximately(float a, float b = 1f)
         {
             // For our easing functions, we typically compare with 1 or 0
             // Using subtraction is faster than Mathf.Abs for this case

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -126,11 +126,12 @@ namespace JANOARG.Shared.Data.ChartInfo
             };
         }
         
-        public static float GetDelayedEase(float x, float delay, EaseFunction func, EaseMode mode, float scale = 1) =>
-            Ease.Get(x * scale - delay, func, mode);
+        
+        public static float GetDelayed(float x, float delay, EaseFunction func, EaseMode mode, float scale = 1) =>
+            Get(x * scale - delay, func, mode);
             
-        public static float GetMultipliedEase(float x, float scale, EaseFunction func, EaseMode mode) =>
-            Ease.Get(x * scale, func, mode);
+        public static float GetMultiplied(float x, float scale, EaseFunction func, EaseMode mode) =>
+            Get(x * scale, func, mode);
         
 
         // We don't need DOTween, guys

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -129,35 +130,29 @@ namespace JANOARG.Shared.Data.ChartInfo
             
         }
 
-        public static float Get(float x, EaseFunction easeFunc, EaseMode mode)
+        [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")] // We don't care about floating point errors here
+        public static float Get(float x, EaseFunction easeFunc, EaseMode mode, float multiplier = 1, float delay = 0, float xPow = 1)
         {
-            //Ease funcs = sEases[(int)easeFunc];
             x = x > 1 ? 1 : x;
             x = x < 0 ? 0 : x;
+            
+            // Only operate on non-default optional parameters
+            x = delay != 0 ? x - delay : x;
+            x = multiplier != 1f ? x * multiplier : x;
+            x = xPow != 1f ? FastPow(x, xPow) : x;
     
+            // No need to cache on static readonly arrays
             return mode switch
             {
-                EaseMode.In => sEases[(int)easeFunc].In(x),
-                EaseMode.Out => sEases[(int)easeFunc].Out(x), 
-                _ => sEases[(int)easeFunc].InOut(x)
+                EaseMode.In => srEases[(int)easeFunc].In(x),
+                EaseMode.Out => srEases[(int)easeFunc].Out(x), 
+                _ => srEases[(int)easeFunc].InOut(x)
             };
         }
-        
-        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        // ReSharper disable once MethodOverloadWithOptionalParameter
-        public static float Get(float x, EaseFunction func, EaseMode mode, float multiplier = 1, float delay = 0) =>
-            Get(x * multiplier - delay, func, mode);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float GetSharpened(float x, float p, EaseFunction func, EaseMode mode, float multiplier = 1, float delay = 0) =>
             FastPow(Get(x * multiplier - delay, func, mode), p);
-        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float GetPreSharp(float x, float p, EaseFunction func, EaseMode mode, float multiplier = 1, float delay = 0) =>
-            Get(FastPow(x *  multiplier - delay, p), func, mode, multiplier);
-
-        
 
         // We don't need DOTween, guys
         

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -78,22 +78,25 @@ namespace JANOARG.Shared.Data.ChartInfo
         // Task Async alternative
         public static async Task AnimateTask(float duration, Action<float> callback)
         {
-            for (float a = 0; a < 1; a += Time.deltaTime / duration)
+            float a = 0;
+            while (a < 1)
             {
                 callback(a);
-                await Task.Yield();
+                await Task.Yield(); // return next frame
+                a += Time.deltaTime / duration;
             }
-
-            callback(1);
+            callback(1f);
         }
+
 
         public static async Task AnimateTask(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode> callback)
         {
-            for (float a = 0; a < 1; a += Time.deltaTime / duration)
+            float a = 0f;
+            while (a < 1)
             {
                 callback(a, easeFunc, mode);
-
                 await Task.Yield();
+                a += Time.deltaTime / duration;
             }
 
             callback(1, easeFunc, mode);

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -531,7 +531,7 @@ namespace JANOARG.Shared.Data.ChartInfo
                     if (x == 0) return 0;
                     if (FastApproximately(x, 1)) return 1;
 
-                    return -FastPow(2, 10 * x - 10) * Mathf.Sin((x * 10 - _ELASTIC_IN_OFFSET) * _ELASTIC_PERIOD);
+                    return -FastPow(2, 10 * x - 10) * FastSin((x * 10 - _ELASTIC_IN_OFFSET) * _ELASTIC_PERIOD);
                 },
                 Out = (x) =>
                 {
@@ -540,7 +540,7 @@ namespace JANOARG.Shared.Data.ChartInfo
 
                     if (FastApproximately(x, 1)) return 1;
 
-                    return FastPow(2, -10 * x) * Mathf.Sin((x * 10 - _ELASTIC_OUT_OFFSET) * _ELASTIC_PERIOD) + 1;
+                    return FastPow(2, -10 * x) * FastSin((x * 10 - _ELASTIC_OUT_OFFSET) * _ELASTIC_PERIOD) + 1;
                 },
                 InOut = (x) =>
                 {
@@ -548,9 +548,9 @@ namespace JANOARG.Shared.Data.ChartInfo
                     if (x == 0) return 0;
                     if (FastApproximately(x, 1)) return 1;
 
-                    if (x < 0.5) return -(FastPow(2, 20 * x - 10) * Mathf.Sin((20 * x - _ELASTIC_PERIOD_IN_OUT_INNER) * _ELASTIC_PERIOD)) / 2;
+                    if (x < 0.5) return -(FastPow(2, 20 * x - 10) * FastSin((20 * x - _ELASTIC_PERIOD_IN_OUT_INNER) * _ELASTIC_PERIOD)) / 2;
 
-                    return FastPow(2, -20 * x + 10) * Mathf.Sin((20 * x - _ELASTIC_PERIOD_IN_OUT_INNER) * _ELASTIC_PERIOD) / 2 + 1;
+                    return FastPow(2, -20 * x + 10) * FastSin((20 * x - _ELASTIC_PERIOD_IN_OUT_INNER) * _ELASTIC_PERIOD) / 2 + 1;
                 }
             };
 

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -132,14 +132,14 @@ namespace JANOARG.Shared.Data.ChartInfo
         [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")] // We don't care about floating point errors here
         public static float Get(float x, EaseFunction easeFunc, EaseMode mode, float multiplier = 1, float delay = 0, float xPow = 1)
         {
+            // Only operate on non-default optional parameters
+            x = multiplier != 1f ? x * multiplier   : x;
+            x = delay      != 0f ? x - delay        : x;
+            x = xPow       != 1f ? FastPow(x, xPow) : x;
+            
             x = x > 1 ? 1 : x;
             x = x < 0 ? 0 : x;
             
-            // Only operate on non-default optional parameters
-            x = delay != 0 ? x - delay : x;
-            x = multiplier != 1f ? x * multiplier : x;
-            x = xPow != 1f ? FastPow(x, xPow) : x;
-    
             // No need to cache on static readonly arrays
             return mode switch
             {

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -725,11 +725,12 @@ namespace JANOARG.Shared.Data.ChartInfo
 
             srEases[(int)EaseFunction.Circle] = new Ease
             {
-                In = (x) => 1 - FastSqrt(1 - (x * x)),
-                Out = (x) => FastSqrt(1 - ((x - 1) * (x - 1))),
-                InOut = (x) => x < 0.5
-                    ? (1 - FastSqrt(1 - ((2 * x) * (2 * x)))) / 2
-                    : (FastSqrt(1 - ((-2 * x + 2) * (-2 * x + 2))) + 1) / 2
+                // PseudoFastSqrt is more visually stable than FastSqrt for this case
+                In = x => 1 - PseudoFastSqrt(1 - (x * x)),
+                Out = x => PseudoFastSqrt(1 - ((x - 1) * (x - 1))),
+                InOut = x => x < 0.5
+                    ? (1 - PseudoFastSqrt(1 - ((2 * x) * (2 * x)))) / 2
+                    : (PseudoFastSqrt(1 - ((-2 * x + 2) * (-2 * x + 2))) + 1) / 2
             };
 
             srEases[(int)EaseFunction.Back] = new Ease

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -516,7 +516,8 @@ namespace JANOARG.Shared.Data.ChartInfo
         {
             
             // Wrap angle to [-PI, PI]
-            x = (x + _PI) % (2 * _PI) - _PI;
+            // Note: C# % is remainder, not modulo — floor-based wrap handles negative x correctly
+            x -= (2 * _PI) * MathF.Floor((x + _PI) / (2 * _PI));
             
             const float B = 4f / _PI;
             const float C = -4f / (_PI * _PI);
@@ -561,11 +562,8 @@ namespace JANOARG.Shared.Data.ChartInfo
         }
 
         // Fast power function for any base
-        public static float FastPow(float a, float b, bool forceCalc = false)
+        public static float FastPow(float a, float b)
         { 
-            // Testing
-            //return Mathf.Pow(a, b);
-            
             // Domain checks first
             Debug.Assert(a >= 0f, "FastPow(float, float): input must be non-negative.");
             Debug.Assert(!float.IsNaN(a) && !float.IsNaN(b));
@@ -585,9 +583,6 @@ namespace JANOARG.Shared.Data.ChartInfo
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float FastSqrt(float x, bool precision = false)
         {
-            // Testing
-            //return Mathf.Sqrt(x);
-            
             Debug.Assert(x >= 0f, "FastSqrt(float): input must be non-negative.");
 
             if (x == 0f) return 0f;
@@ -605,6 +600,10 @@ namespace JANOARG.Shared.Data.ChartInfo
             if (precision)
                 y = COEFFICIENT * (y + x / y);
 
+            // Note: this clamps output to [0, 1], making it incorrect for inputs > 1.
+            // This is intentional for easing contexts where values are always normalized,
+            // but use PseudoFastSqrt (FastPow(x, 0.5f)) instead if visual stability is
+            // a concern, as it is more consistent for Circle easing and similar curves.
             y = y > 1 ? 1 : y;
             y = y < 0 ? 0 : y;
             
@@ -646,7 +645,7 @@ namespace JANOARG.Shared.Data.ChartInfo
             return diff is < _EPSILON and > -_EPSILON;
         }
         
-        public static readonly Ease[] srEases;
+        private static readonly Ease[] srEases;
 
         // We will reduce as much external calls as possible,
         // given this library is being called ~3000+ times per frame
@@ -865,8 +864,7 @@ namespace JANOARG.Shared.Data.ChartInfo
         private void UpdateSamples()
         {
             float step = 1.0f / (_Samples.Length - 1);
-            for (var t = 0; t < _Samples.Length - 1; t++)
-                _Samples[t] = GetBezier(t * step, Point1.x, Point2.x);
+            for (var t = 0; t < _Samples.Length - 1; t++) _Samples[t] = GetBezier(t * step, Point1.x, Point2.x);
         }
 
         public float Get(float x)
@@ -912,7 +910,8 @@ namespace JANOARG.Shared.Data.ChartInfo
 
         private float BinarySearchApprox(float x, float minBound, float maxBound)
         {
-            float t, xDiff, i = 0;
+            float t, xDiff;
+            int i = 0;
 
             do
             {
@@ -922,7 +921,7 @@ namespace JANOARG.Shared.Data.ChartInfo
                 if (xDiff < 0) minBound = t;
                 else maxBound = t;
             }
-            while (Mathf.Abs(xDiff) < _BINARY_SEARCH_PRECISION && i < _BINARY_SEARCH_MAX_ITERATIONS);
+            while (Mathf.Abs(xDiff) > _BINARY_SEARCH_PRECISION && i++ < _BINARY_SEARCH_MAX_ITERATIONS);
 
             return t;
         }

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -107,26 +108,21 @@ namespace JANOARG.Shared.Data.ChartInfo
         
     }
 
-    [Serializable]
     public class Ease
     {
         public Func<float, float> In;
         public Func<float, float> Out;
         public Func<float, float> InOut;
 
-        private static bool s_cancelRequested;
-        private static bool s_forceCancelRequested;
-        
         /// <summary>
-        /// Properly finish the current Animate loop by skipping to callback(1).
-        /// Recommended to use this over StopCoroutine.
+        /// Skips all currently active Ease.Animate coroutines.
+        /// Also cleans up any stale handlers left by external StopCoroutine calls.
         /// </summary>
-        public static void Skip(bool force = false)
+        public static void SkipAll(bool force = false)
         {
-            s_cancelRequested = true;
-            
-            if (force) s_forceCancelRequested = true;
-            
+            foreach (var weak in EaseEnumerator.s_active)
+                if (weak.TryGetTarget(out var handler))
+                    handler.Skip(force);
         }
 
         [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")] // We don't care about floating point errors here
@@ -154,35 +150,33 @@ namespace JANOARG.Shared.Data.ChartInfo
             FastPow(Get(x * multiplier - delay, func, mode), p);
 
         // We don't need DOTween, guys
-        
+
         /// <summary>
         /// Animates a value from 0 to 1 over specified duration, invoking callback each frame with linear progress.
-        /// Supports cancellation via Ease.Skip
+        /// Supports individual cancellation via the returned handler, or Ease.SkipAll for all active animations.
         /// </summary>
         /// <param name="duration">Total animation time in seconds</param>
         /// <param name="callback">Action receiving linear progress (0 to 1) each frame</param>
-        public static IEnumerator Animate(float duration, Action<float> callback)
+        /// <returns>An AnimCoroutineHandler that can be passed to StartCoroutine and used to Skip individually.</returns>
+        public static EaseEnumerator Animate(float duration, Action<float> callback) =>
+            new EaseEnumerator(EaseEnumerator(duration, callback));
+
+        private static IEnumerator EaseEnumerator(float duration, Action<float> callback)
         {
+            var handler = EaseEnumerator.Current;
             for (float a = 0; a < 1; a += Time.deltaTime / duration)
             {
-                if (s_cancelRequested)
+                if (handler.CancelRequested)
                 {
-                    s_cancelRequested = false;
+                    handler.CancelRequested = false;
                     break;
                 }
-                
                 callback(a);
-
                 yield return null;
             }
-
-            if (s_forceCancelRequested)
-            {
-                s_forceCancelRequested = false;
-                yield break;
-            }
-
+            if (handler.ForceCancelRequested) { handler.ForceCancelRequested = false; handler.MarkComplete(); yield break; }
             callback(1);
+            handler.MarkComplete();
         }
 
         /// <summary>
@@ -193,29 +187,28 @@ namespace JANOARG.Shared.Data.ChartInfo
         /// <param name="easeFunc">Easing function type</param>
         /// <param name="mode">Easing mode (In/Out/InOut)</param>
         /// <param name="callback">Action receiving (progress, easeFunc, mode) each frame</param>
-        public static IEnumerator Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode> callback)
+        /// <returns>An AnimCoroutineHandler that can be passed to StartCoroutine and used to Skip individually.</returns>
+        public static EaseEnumerator Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode> callback) =>
+            new EaseEnumerator(EaseEnumerator(duration, easeFunc, mode, callback));
+
+        private static IEnumerator EaseEnumerator(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode> callback)
         {
+            var handler = EaseEnumerator.Current;
             for (float a = 0; a < 1; a += Time.deltaTime / duration)
             {
-                if (s_cancelRequested)
+                if (handler.CancelRequested)
                 {
-                    s_cancelRequested = false;
+                    handler.CancelRequested = false;
                     break;
                 }
-                
                 callback(a, easeFunc, mode);
-
                 yield return null;
             }
-
-            if (s_forceCancelRequested)
-            {
-                s_forceCancelRequested = false;
-                yield break;
-            }
+            if (handler.ForceCancelRequested) { handler.ForceCancelRequested = false; handler.MarkComplete(); yield break; }
             callback(1, easeFunc, mode);
+            handler.MarkComplete();
         }
-        
+
         /// <summary>
         /// Animates with easing, automatically calculating eased value and providing all parameters.
         /// Most comprehensive version - gives access to raw progress, ease parameters shortcuts, and pre-calculated eased value.
@@ -224,32 +217,31 @@ namespace JANOARG.Shared.Data.ChartInfo
         /// <param name="easeFunc">Easing function type</param>
         /// <param name="mode">Easing mode (In/Out/InOut)</param>
         /// <param name="callback">Action receiving (progress, easeFunc, mode, easedValue) each frame</param>
-        public static IEnumerator Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode, float> callback)
+        /// <returns>An AnimCoroutineHandler that can be passed to StartCoroutine and used to Skip individually.</returns>
+        public static EaseEnumerator Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode, float> callback) =>
+            new EaseEnumerator(EaseEnumerator(duration, easeFunc, mode, callback));
+
+        private static IEnumerator EaseEnumerator(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode, float> callback)
         {
+            var handler = EaseEnumerator.Current;
             float ease;
             for (float a = 0; a < 1; a += Time.deltaTime / duration)
             {
-                if (s_cancelRequested)
+                if (handler.CancelRequested)
                 {
-                    s_cancelRequested = false;
+                    handler.CancelRequested = false;
                     break;
                 }
-                
                 ease = Get(a, easeFunc, mode);
                 callback(a, easeFunc, mode, ease);
-
                 yield return null;
             }
-
-            if (s_forceCancelRequested)
-            {
-                s_forceCancelRequested = false;
-                yield break;
-            }
+            if (handler.ForceCancelRequested) { handler.ForceCancelRequested = false; handler.MarkComplete(); yield break; }
             ease = Get(1, easeFunc, mode);
             callback(1, easeFunc, mode, ease);
+            handler.MarkComplete();
         }
-        
+
         /// <summary>
         /// Animates with easing, automatically calculating, and providing only the eased value to callback.
         /// Simplest eased animation - callback receives only the pre-calculated eased progress (0 to 1).
@@ -258,40 +250,52 @@ namespace JANOARG.Shared.Data.ChartInfo
         /// <param name="easeFunc">Easing function type</param>
         /// <param name="mode">Easing mode (In/Out/InOut)</param>
         /// <param name="callback">Action receiving eased progress value (0 to 1) each frame</param>
-        public static IEnumerator Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float> callback)
+        /// <returns>An AnimCoroutineHandler that can be passed to StartCoroutine and used to Skip individually.</returns>
+        public static EaseEnumerator Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float> callback) =>
+            new EaseEnumerator(EaseEnumerator(duration, easeFunc, mode, callback));
+
+        private static IEnumerator EaseEnumerator(float duration, EaseFunction easeFunc, EaseMode mode, Action<float> callback)
         {
+            var handler = EaseEnumerator.Current;
             float ease;
             for (float a = 0; a < 1; a += Time.deltaTime / duration)
             {
-                if (s_cancelRequested)
+                if (handler.CancelRequested)
                 {
-                    s_cancelRequested = false;
+                    handler.CancelRequested = false;
                     break;
                 }
-                
                 ease = Get(a, easeFunc, mode);
                 callback(ease);
-
                 yield return null;
             }
-
-            if (s_forceCancelRequested)
-            {
-                s_forceCancelRequested = false;
-                yield break;
-            }
+            if (handler.ForceCancelRequested) { handler.ForceCancelRequested = false; handler.MarkComplete(); yield break; }
             ease = Get(1, easeFunc, mode);
             callback(ease);
+            handler.MarkComplete();
         }
         
         // Task Async alternative
         // Note: This one tries to avoid Unity dependencies, so DeltaTime is not used
         // This may not play well with Unity threads so use this with caution.
         // It is recommended to replace DateTime with your own available clock implementations
-        
+
+        private static bool s_taskCancelRequested;
+        private static bool s_taskForceCancelRequested;
+
+        /// <summary>
+        /// Cancels all active Task-based Ease.Animate calls.
+        /// Non-force: snaps to callback(1). Force: aborts without callback(1).
+        /// </summary>
+        public static void SkipAsync(bool force = false)
+        {
+            s_taskCancelRequested = true;
+            if (force) s_taskForceCancelRequested = true;
+        }
+
         /// <summary>
         /// Animates a value from 0 to 1 over specified duration, invoking callback each frame with linear progress.
-        /// Supports cancellation via Ease.Skip
+        /// Supports cancellation via Ease.SkipAsync
         /// </summary>
         /// <param name="duration">Total animation time in seconds</param>
         /// <param name="callback">Action receiving linear progress (0 to 1) each frame</param>
@@ -303,9 +307,9 @@ namespace JANOARG.Shared.Data.ChartInfo
 
             while (DateTime.Now < endTime)
             {
-                if (s_cancelRequested || cancellationToken.IsCancellationRequested)
+                if (s_taskCancelRequested || cancellationToken.IsCancellationRequested)
                 {
-                    s_cancelRequested = false;
+                    s_taskCancelRequested = false;
                     return;
                 }
 
@@ -317,9 +321,9 @@ namespace JANOARG.Shared.Data.ChartInfo
                 await Task.Yield();
             }
 
-            if (s_forceCancelRequested || cancellationToken.IsCancellationRequested)
+            if (s_taskForceCancelRequested || cancellationToken.IsCancellationRequested)
             {
-                s_forceCancelRequested = false;
+                s_taskForceCancelRequested = false;
                 return;
             }
 
@@ -342,9 +346,9 @@ namespace JANOARG.Shared.Data.ChartInfo
 
             while (DateTime.Now < endTime)
             {
-                if (s_cancelRequested || cancellationToken.IsCancellationRequested)
+                if (s_taskCancelRequested || cancellationToken.IsCancellationRequested)
                 {
-                    s_cancelRequested = false;
+                    s_taskCancelRequested = false;
                     return;
                 }
 
@@ -357,9 +361,9 @@ namespace JANOARG.Shared.Data.ChartInfo
                 await Task.Yield();
             }
 
-            if (s_forceCancelRequested || cancellationToken.IsCancellationRequested)
+            if (s_taskForceCancelRequested || cancellationToken.IsCancellationRequested)
             {
-                s_forceCancelRequested = false;
+                s_taskForceCancelRequested = false;
                 return;
             }
 
@@ -383,9 +387,9 @@ namespace JANOARG.Shared.Data.ChartInfo
 
             while (DateTime.Now < endTime)
             {
-                if (s_cancelRequested || cancellationToken.IsCancellationRequested)
+                if (s_taskCancelRequested || cancellationToken.IsCancellationRequested)
                 {
-                    s_cancelRequested = false;
+                    s_taskCancelRequested = false;
                     return;
                 }
 
@@ -397,9 +401,9 @@ namespace JANOARG.Shared.Data.ChartInfo
                 await Task.Yield();
             }
 
-            if (s_forceCancelRequested || cancellationToken.IsCancellationRequested)
+            if (s_taskForceCancelRequested || cancellationToken.IsCancellationRequested)
             {
-                s_forceCancelRequested = false;
+                s_taskForceCancelRequested = false;
                 return;
             }
 
@@ -422,9 +426,9 @@ namespace JANOARG.Shared.Data.ChartInfo
 
             while (DateTime.Now < endTime)
             {
-                if (s_cancelRequested || cancellationToken.IsCancellationRequested)
+                if (s_taskCancelRequested || cancellationToken.IsCancellationRequested)
                 {
-                    s_cancelRequested = false;
+                    s_taskCancelRequested = false;
                     return;
                 }
 
@@ -437,9 +441,9 @@ namespace JANOARG.Shared.Data.ChartInfo
                 await Task.Yield();
             }
 
-            if (s_forceCancelRequested || cancellationToken.IsCancellationRequested)
+            if (s_taskForceCancelRequested || cancellationToken.IsCancellationRequested)
             {
-                s_forceCancelRequested = false;
+                s_taskForceCancelRequested = false;
                 return;
             }
 
@@ -838,7 +842,7 @@ namespace JANOARG.Shared.Data.ChartInfo
         public readonly Vector2 Point1;
         public readonly Vector2 Point2;
 
-        [SerializeField] private float[] _Samples;
+        private readonly float[] _Samples;
 
         public CubicBezierEaseDirective(Vector2 point1, Vector2 point2)
         {
@@ -871,9 +875,6 @@ namespace JANOARG.Shared.Data.ChartInfo
         {
             if (x == 0 || Ease.FastApproximately(x, 1)) return x;
 
-            Debug.Assert(_Samples != null, "CubicBezierEaseDirective: Samples array is null");
-            Debug.Assert(_Samples.Length > 1, "CubicBezierEaseDirective: Samples array is empty");
-            
             int nIndex = Array.FindIndex(_Samples, n => n > x);
             nIndex = Math.Max(nIndex, 1);
 
@@ -951,5 +952,79 @@ namespace JANOARG.Shared.Data.ChartInfo
         {
             return "CubicBézier";
         }
+    }
+
+    /// <summary>
+    /// Wraps an Ease.Animate coroutine, providing per-animation Skip control and completion tracking.
+    /// Compatible with all IEnumerator usage patterns:
+    ///   yield return Ease.Animate(...)        — non-breaking
+    ///   StartCoroutine(Ease.Animate(...))     — non-breaking
+    ///   var anim = Ease.Animate(...);
+    ///   StartCoroutine(anim); anim.Skip();   — new: individual skip
+    ///
+    /// Warning: if Unity's StopCoroutine is called externally, IsComplete will not update automatically.
+    /// Call anim.Complete() manually after StopCoroutine to keep state consistent.
+    /// </summary>
+    public class EaseEnumerator : IEnumerator
+    {
+        internal static readonly List<WeakReference<EaseEnumerator>> s_active = new();
+
+        // ThreadStatic so EaseEnumerator can retrieve its own handler during construction
+        [ThreadStatic]
+        internal static EaseEnumerator Current;
+
+        private readonly IEnumerator _inner;
+
+        internal bool CancelRequested;
+        internal bool ForceCancelRequested;
+
+        /// <summary>True once the animation has naturally completed or Complete() was called.</summary>
+        public bool IsComplete { get; private set; }
+
+        object IEnumerator.Current => _inner.Current;
+
+        internal EaseEnumerator(IEnumerator inner)
+        {
+            _inner = inner;
+            s_active.Add(new WeakReference<EaseEnumerator>(this));
+        }
+
+        /// <summary>
+        /// Snaps the animation to its end state (calls callback(1)).
+        /// Use Skip(force: true) to abort without calling callback(1).
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if the animation is already complete.</exception>
+        public void Skip(bool force = false)
+        {
+            if (IsComplete)
+                throw new InvalidOperationException("Cannot Skip an animation that has already completed. Check IsComplete before calling Skip.");
+
+            CancelRequested = true;
+            if (force) ForceCancelRequested = true;
+        }
+
+        /// <summary>
+        /// Marks the animation as complete and removes it from the active list.
+        /// Call this manually after StopCoroutine to keep IsComplete and SkipAll consistent.
+        /// </summary>
+        public void Complete() => MarkComplete();
+
+        internal void MarkComplete()
+        {
+            IsComplete = true;
+            s_active.RemoveAll(w => !w.TryGetTarget(out var t) || t == this);
+        }
+
+        public bool MoveNext()
+        {
+            // Set Current so EaseEnumerator can retrieve its handler via AnimCoroutineHandler.Current
+            Current = this;
+            bool hasNext = _inner.MoveNext();
+            Current = null;
+            if (!hasNext) MarkComplete();
+            return hasNext;
+        }
+
+        public void Reset() => _inner.Reset();
     }
 }

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -36,15 +36,15 @@ namespace JANOARG.Shared.Data.ChartInfo
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float LerpTo(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
-            (1 - Ease.Get(interpolator, easeFunc, mode)) * from + Ease.Get(interpolator, easeFunc, mode) * to;
+            from + (to - from) * Ease.Get(interpolator, easeFunc, mode);
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float InverseLerpTo(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
-            Ease.Get(interpolator, easeFunc, mode) * from + (1 - Ease.Get(interpolator, easeFunc, mode)) * to;
+            to - (to - from) * Ease.Get(interpolator, easeFunc, mode);
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float LerpBy(float from, float delta, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
-            (1 - Ease.Get(interpolator, easeFunc, mode)) * from + Ease.Get(interpolator, easeFunc, mode) * (from + delta);
+            from + delta * Ease.Get(interpolator, easeFunc, mode);
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float InverseLerpBy(float from, float delta, float interpolator, EaseFunction easeFunc, EaseMode mode) =>

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -146,7 +146,73 @@ namespace JANOARG.Shared.Data.ChartInfo
                 elapsedTime += Time.deltaTime;
             }
         }
+        
+        private const float _PI      = Mathf.PI;
+        private const float _PI_HALF = _PI / 2;
+        private const float _EPSILON  = 0.000001f;
+        
+        private const float _BACK_OVERSHOOT        = 1.70158f;
+        private const float _BACK_SCALED_OVERSHOOT = _BACK_OVERSHOOT * 1.525f;
 
+        private const float _ELASTIC_PERIOD_IN_OUT_INNER = 11.125f;
+
+        private const float _ELASTIC_PERIOD     = _PI * 2 / 3f;
+        private const float _ELASTIC_IN_OFFSET  = 10.75f;
+        private const float _ELASTIC_OUT_OFFSET = 0.75f;
+
+        private const float _BOUNCE_CONSTANT  = 7.5625f;
+        private const float _BOUNCE_THRESHOLD = 2.75f;
+        
+        private static float FastSin(float x)
+        {
+            const float B = 4f / _PI;
+            const float C = -4f / (_PI * _PI);
+                
+            float y = B * x + C * x * Mathf.Abs(x);
+                
+            // Optional extra precision (at some performance cost)
+            const float P = 0.225f;
+            y = P * (y * Mathf.Abs(y) - y) + y;
+                
+            return y;
+        }
+            
+        private static float FastCos(float x)
+        {
+            // Cos in a nutshell: Sine, just translated back by 90 degrees (but we're using rad so yeah)
+            return FastSin(_PI_HALF - x);
+        }
+
+        // Fast power approximation for base 2
+        private static float FastPow2(float p)
+        {
+            float offset = (p < 0) ? 1.0f : 0.0f;
+            float clipp = (p < -126) ? -126.0f : p;
+            int w = (int)clipp;
+            float z = clipp - w + offset;
+        
+            // This is a approximation of 2^z in range [0,1)
+            // Using bit shifting of constants I cannot comprehend (it's the same kind of workaround to do division in assembly)
+            return BitConverter.Int32BitsToSingle(
+                (int)((1 << 23) * (clipp + 121.2740575f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z)));
+        }
+
+        // Fast power function for any base
+        private static float FastPow(float a, float b)
+        {
+            // Logarithm shouldn't be costly, I think?
+            return FastPow2(b * Mathf.Log(a, 2));
+        }
+        
+        // Fast approximate equality check
+        private static bool FastApproximately(float a, float b = 1f)
+        {
+            // For our easing functions, we typically compare with 1 or 0
+            // Using subtraction is faster than Mathf.Abs for this case
+            float diff = a - b;
+            return diff is < _EPSILON and > -_EPSILON;
+        }
+        
         public static Ease[] sEases;
 
         // We will reduce as much external calls as possible,
@@ -164,9 +230,9 @@ namespace JANOARG.Shared.Data.ChartInfo
 
             sEases[(int)EaseFunction.Sine] = new Ease
             {
-                In = (x) => 1 - Mathf.Cos(x * Mathf.PI / 2),
-                Out = (x) => Mathf.Sin(x * Mathf.PI / 2),
-                InOut = (x) => (1 - Mathf.Cos(x * Mathf.PI)) / 2
+                In = (x) => 1 - FastCos(x * _PI / 2),
+                Out = (x) => FastSin(x * _PI / 2),
+                InOut = (x) => (1 - FastCos(x * _PI)) / 2
             };
 
             sEases[(int)EaseFunction.Quadratic] = new Ease
@@ -211,17 +277,17 @@ namespace JANOARG.Shared.Data.ChartInfo
             {
                 In = (x) => x == 0
                     ? 0
-                    : Mathf.Pow(2, 10 * x - 10) - 0.0009765625f * (1 - x),
-                Out = (x) => Mathf.Approximately(x, 1)
+                    : FastPow(2, 10 * x - 10) - 0.0009765625f * (1 - x),
+                Out = (x) => FastApproximately(x, 1)
                     ? 1
-                    : 1 - Mathf.Pow(2, -10 * x) + 0.0009765625f * x,
+                    : 1 - FastPow(2, -10 * x) + 0.0009765625f * x,
                 InOut = (x) => x == 0
                     ? 0
-                    : Mathf.Approximately(x, 1)
+                    : FastApproximately(x, 1)
                         ? 1
                         : x < 0.5
-                            ? Mathf.Pow(2, 20 * x - 10) / 2 - 0.0009765625f * (1 - x)
-                            : (2 - Mathf.Pow(2, -20 * x + 10)) / 2 + 0.0009765625f * x
+                            ? FastPow(2, 20 * x - 10) / 2 - 0.0009765625f * (1 - x)
+                            : (2 - FastPow(2, -20 * x + 10)) / 2 + 0.0009765625f * x
             };
 
             sEases[(int)EaseFunction.Circle] = new Ease
@@ -235,66 +301,40 @@ namespace JANOARG.Shared.Data.ChartInfo
 
             sEases[(int)EaseFunction.Back] = new Ease
             {
-                In = (x) =>
-                {
-                    const float OVERSHOOT = 1.70158f;
-
-                    return 2.70158f * x * x * x - OVERSHOOT * x * x;
-                },
-                Out = (x) =>
-                {
-                    const float OVERSHOOT = 1.70158f;
-
-                    return 1 + 2.70158f * ((x - 1) * (x - 1) * (x - 1)) + OVERSHOOT * ((x - 1) * (x - 1));
-                },
-                InOut = (x) =>
-                {
-                    const float OVERSHOOT = 1.70158f;
-                    const float SCALED_OVERSHOOT = OVERSHOOT * 1.525f;
-
-                    return x < 0.5f
-                        ? ((2 * x) * (2 * x)) * ((SCALED_OVERSHOOT + 1) * 2 * x - SCALED_OVERSHOOT) / 2
-                        : (((2 * x - 2) * (2 * x - 2))* ((SCALED_OVERSHOOT + 1) * (x * 2 - 2) + SCALED_OVERSHOOT) + 2) / 2;
-                }
+                In = (x) => 2.70158f * x * x * x - _BACK_OVERSHOOT * x * x,
+                Out = (x) => 1 + 2.70158f * ((x - 1) * (x - 1) * (x - 1)) + _BACK_OVERSHOOT * ((x - 1) * (x - 1)),
+                InOut = (x) => x < 0.5f
+                    ? ((2 * x) * (2 * x)) * ((_BACK_SCALED_OVERSHOOT + 1) * 2 * x - _BACK_SCALED_OVERSHOOT) / 2
+                    : (((2 * x - 2) * (2 * x - 2))* ((_BACK_SCALED_OVERSHOOT + 1) * (x * 2 - 2) + _BACK_SCALED_OVERSHOOT) + 2) / 2
             };
 
             sEases[(int)EaseFunction.Elastic] = new Ease
             {
                 In = (x) =>
                 {
-                    const float PERIOD = Mathf.PI * 2 / 3;
-
                     if (x == 0) return 0;
-                    if (Mathf.Approximately(x, 1)) return 1;
+                    if (FastApproximately(x, 1)) return 1;
 
-                    return -Mathf.Pow(2, 10 * x - 10) * Mathf.Sin((x * 10 - 10.75f) * PERIOD);
+                    return -FastPow(2, 10 * x - 10) * Mathf.Sin((x * 10 - _ELASTIC_IN_OFFSET) * _ELASTIC_PERIOD);
                 },
                 Out = (x) =>
                 {
-                    const float PERIOD = Mathf.PI * 2 / 3;
 
-                    if (x == 0)
-                        return 0;
+                    if (x == 0) return 0;
 
-                    if (Mathf.Approximately(x, 1))
-                        return 1;
+                    if (FastApproximately(x, 1)) return 1;
 
-                    return Mathf.Pow(2, -10 * x) * Mathf.Sin((x * 10 - 0.75f) * PERIOD) + 1;
+                    return FastPow(2, -10 * x) * Mathf.Sin((x * 10 - _ELASTIC_OUT_OFFSET) * _ELASTIC_PERIOD) + 1;
                 },
                 InOut = (x) =>
                 {
-                    const float PERIOD = Mathf.PI * 2 / 4.5f;
 
-                    if (x == 0)
-                        return 0;
+                    if (x == 0) return 0;
+                    if (FastApproximately(x, 1)) return 1;
 
-                    if (Mathf.Approximately(x, 1))
-                        return 1;
+                    if (x < 0.5) return -(FastPow(2, 20 * x - 10) * Mathf.Sin((20 * x - _ELASTIC_PERIOD_IN_OUT_INNER) * _ELASTIC_PERIOD)) / 2;
 
-                    if (x < 0.5)
-                        return -(Mathf.Pow(2, 20 * x - 10) * Mathf.Sin((20 * x - 11.125f) * PERIOD)) / 2;
-
-                    return Mathf.Pow(2, -20 * x + 10) * Mathf.Sin((20 * x - 11.125f) * PERIOD) / 2 + 1;
+                    return FastPow(2, -20 * x + 10) * Mathf.Sin((20 * x - _ELASTIC_PERIOD_IN_OUT_INNER) * _ELASTIC_PERIOD) / 2 + 1;
                 }
             };
 
@@ -303,20 +343,18 @@ namespace JANOARG.Shared.Data.ChartInfo
                 In = (x) => 1 - Get(1 - x, EaseFunction.Bounce, EaseMode.Out),
                 Out = (x) =>
                 {
-                    const float BOUNCE_CONSTANT = 7.5625f;
-                    const float BOUNCE_THRESHOLD = 2.75f;
 
-                    if (x < 1 / BOUNCE_THRESHOLD)
-                        return BOUNCE_CONSTANT * (x * x);
+                    if (x < 1 / _BOUNCE_THRESHOLD)
+                        return _BOUNCE_CONSTANT * (x * x);
 
 
-                    if (x < 2 / BOUNCE_THRESHOLD)
-                        return BOUNCE_CONSTANT * (x -= 1.5f / BOUNCE_THRESHOLD) * x + 0.75f;
+                    if (x < 2 / _BOUNCE_THRESHOLD)
+                        return _BOUNCE_CONSTANT * (x -= 1.5f / _BOUNCE_THRESHOLD) * x + 0.75f;
 
-                    if (x < 2.5 / BOUNCE_THRESHOLD)
-                        return BOUNCE_CONSTANT * (x -= 2.25f / BOUNCE_THRESHOLD) * x + 0.9375f;
+                    if (x < 2.5 / _BOUNCE_THRESHOLD)
+                        return _BOUNCE_CONSTANT * (x -= 2.25f / _BOUNCE_THRESHOLD) * x + 0.9375f;
 
-                    return BOUNCE_CONSTANT * (x -= 2.625f / BOUNCE_THRESHOLD) * x + 0.984375f;
+                    return _BOUNCE_CONSTANT * (x -= 2.625f / _BOUNCE_THRESHOLD) * x + 0.984375f;
                 },
                 InOut = (x) => x < 0.5
                     ? (1 - Get(1 - 2 * x, EaseFunction.Bounce, EaseMode.Out)) / 2
@@ -369,6 +407,15 @@ namespace JANOARG.Shared.Data.ChartInfo
 
         [SerializeField] private float[] _Samples;
 
+        private const float _EPSILON = 1e-6f;
+
+        // FIXME: Can't be bothered to move the method out of the class scope
+        private static bool FastApproximately(float a, float b = 1f)
+        {
+            float diff = a - b;
+            return diff is < _EPSILON and > -_EPSILON;
+        }
+
         public CubicBezierEaseDirective(Vector2 point1, Vector2 point2)
         {
             Validate(point1);
@@ -399,7 +446,7 @@ namespace JANOARG.Shared.Data.ChartInfo
 
         public float Get(float x)
         {
-            if (x == 0 || Mathf.Approximately(x, 1)) return x;
+            if (x == 0 || FastApproximately(x, 1)) return x;
 
             Debug.Assert(_Samples != null, "CubicBezierEaseDirective: Samples array is null");
             Debug.Assert(_Samples.Length > 1, "CubicBezierEaseDirective: Samples array is empty");
@@ -466,7 +513,7 @@ namespace JANOARG.Shared.Data.ChartInfo
 
                 float currentX = GetBezier(initialGuess, Point1.x, Point2.x);
 
-                if (Mathf.Approximately(targetX, currentX))
+                if (FastApproximately(targetX, currentX))
                     return initialGuess;
 
                 initialGuess -= (currentX - targetX) / slope;

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -631,15 +631,6 @@ namespace JANOARG.Shared.Data.ChartInfo
 
         [SerializeField] private float[] _Samples;
 
-        private const float _EPSILON = 1e-6f;
-
-        // FIXME: Can't be bothered to move the method out of the class scope
-        private static bool FastApproximately(float a, float b = 1f)
-        {
-            float diff = a - b;
-            return diff is < _EPSILON and > -_EPSILON;
-        }
-
         public CubicBezierEaseDirective(Vector2 point1, Vector2 point2)
         {
             Validate(point1);
@@ -670,7 +661,7 @@ namespace JANOARG.Shared.Data.ChartInfo
 
         public float Get(float x)
         {
-            if (x == 0 || FastApproximately(x, 1)) return x;
+            if (x == 0 || Ease.FastApproximately(x, 1)) return x;
 
             Debug.Assert(_Samples != null, "CubicBezierEaseDirective: Samples array is null");
             Debug.Assert(_Samples.Length > 1, "CubicBezierEaseDirective: Samples array is empty");
@@ -737,7 +728,7 @@ namespace JANOARG.Shared.Data.ChartInfo
 
                 float currentX = GetBezier(initialGuess, Point1.x, Point2.x);
 
-                if (FastApproximately(targetX, currentX))
+                if (Ease.FastApproximately(targetX, currentX))
                     return initialGuess;
 
                 initialGuess -= (currentX - targetX) / slope;

--- a/Scripts/Data/ChartInfo/Easing.cs
+++ b/Scripts/Data/ChartInfo/Easing.cs
@@ -35,77 +35,123 @@ namespace JANOARG.Shared.Data.ChartInfo
     [Serializable]
     public static class EaseUtils
     {
+        /// <summary>Eases from <paramref name="from"/> to <paramref name="to"/>. At interpolator=0 returns from, at interpolator=1 returns to.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float LerpTo(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             from + (to - from) * Ease.Get(interpolator, easeFunc, mode);
-        
+
+        /// <summary>Reverse of LerpTo — eases from <paramref name="to"/> back to <paramref name="from"/>. At interpolator=0 returns <paramref name="to"/>, at interpolator=1 returns <paramref name="from"/>.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float InverseLerpTo(float from, float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             to - (to - from) * Ease.Get(interpolator, easeFunc, mode);
-        
+
+        /// <summary>Eases <paramref name="from"/> by <paramref name="delta"/>. Equivalent to LerpTo with an offset instead of an explicit target.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float LerpBy(float from, float delta, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             from + delta * Ease.Get(interpolator, easeFunc, mode);
-        
+
+        /// <summary>Reverse of LerpBy — eases from <paramref name="from"/> + <paramref name="delta"/> back to <paramref name="from"/>.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float InverseLerpBy(float from, float delta, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             from + delta * (1 - Ease.Get(interpolator, easeFunc, mode));
-        
+
+        /// <summary>Eases <paramref name="from"/> toward zero. At interpolator=0 returns <paramref name="from"/>, at interpolator=1 returns 0.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float ToZero(float from, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             from * (1 - Ease.Get(interpolator, easeFunc, mode));
-        
+
+        /// <summary>
+        /// Eases from zero toward <paramref name="to"/>. At interpolator=0 returns 0, at interpolator=1 returns <paramref name="to"/>.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float FromZero(float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             to * Ease.Get(interpolator, easeFunc, mode);
-        
+
+        /// <summary>
+        /// Returns <paramref name="to"/> divided by the eased interpolator.
+        /// Produces a value that starts very large and converges toward <paramref name="to"/> as the ease approaches 1.
+        /// Useful for overshoot or dramatic approach effects. Infinity at interpolator=0 (division by zero).
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float BlastIn(float to, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             to / Ease.Get(interpolator, easeFunc, mode);
 
+        /// <summary>
+        /// Returns <paramref name="from"/> divided by (1 - eased interpolator).
+        /// Produces a value that starts at <paramref name="from"/> and diverges toward infinity as the ease approaches 1.
+        /// Useful for explosive exit or departure effects. Infinity at interpolator=1 (division by zero).
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float BlastOut(float from, float interpolator, EaseFunction easeFunc, EaseMode mode) =>
             from / (1 - Ease.Get(interpolator, easeFunc, mode));
-        
-        
-        // For predefined eases
-        
+
+
+        // Predefined ease overloads — pass a pre-calculated ease value (e.g. from Ease.Get or a cached result)
+        // instead of recomputing it each call. Useful when the same ease value drives multiple properties per frame.
+
+        /// <summary>
+        /// Eases from <paramref name="from"/> to <paramref name="to"/> using a pre-calculated <paramref name="ease"/> value.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float LerpTo(float from, float to, float ease) =>
             (1 - ease) * from + ease * to;
-        
+
+        /// <summary>
+        /// Reverse of LerpTo — eases from <paramref name="to"/> back to <paramref name="from"/> using a pre-calculated <paramref name="ease"/> value.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float InverseLerpTo(float from, float to, float ease) =>
             ease * from + (1 - ease) * to;
 
+        /// <summary>
+        /// Eases from <paramref name="from"/> to <paramref name="from"/> + <paramref name="delta"/> using a pre-calculated <paramref name="ease"/> value.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float LerpBy(float from, float delta, float ease) =>
             (1 - ease) * from + ease * (from + delta);
-        
+
+        /// <summary>
+        /// Reverse of LerpBy using a pre-calculated <paramref name="ease"/> value.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float InverseLerpBy(float from, float delta, float ease) =>
             from + delta * (1 - ease);
-        
+
+        /// <summary>
+        /// Eases <paramref name="from"/> toward zero using a pre-calculated <paramref name="ease"/> value.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float ToZero(float from, float ease) =>
             from * (1 - ease);
-        
+
+        /// <summary>
+        /// Eases from zero toward <paramref name="to"/> using a pre-calculated <paramref name="ease"/> value.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float FromZero(float to, float ease) =>
             to * ease;
-        
+
+        /// <summary>
+        /// Returns <paramref name="to"/> when <paramref name="ease"/> reaches 1, otherwise returns <paramref name="from"/>. Hard cut with no interpolation.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Snap(float from, float to, float ease) =>
             (int)ease == 1 ? to : from;
-        
+
+        /// <summary>
+        /// BlastIn using a pre-calculated <paramref name="ease"/> value. Undefined at ease=0.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float BlastIn(float to, float ease) =>
             to / ease;
-        
+
+        /// <summary>
+        /// BlastOut using a pre-calculated <paramref name="ease"/> value. Undefined at ease=1.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float BlastOut(float from, float ease) =>
             from / (1 - ease);
-        
+
     }
 
     public class Ease
@@ -120,7 +166,7 @@ namespace JANOARG.Shared.Data.ChartInfo
         /// </summary>
         public static void SkipAll(bool force = false)
         {
-            foreach (var weak in EaseEnumerator.s_active)
+            foreach (var weak in AnimCoroutineHandler.s_active)
                 if (weak.TryGetTarget(out var handler))
                     handler.Skip(force);
         }
@@ -158,12 +204,12 @@ namespace JANOARG.Shared.Data.ChartInfo
         /// <param name="duration">Total animation time in seconds</param>
         /// <param name="callback">Action receiving linear progress (0 to 1) each frame</param>
         /// <returns>An AnimCoroutineHandler that can be passed to StartCoroutine and used to Skip individually.</returns>
-        public static EaseEnumerator Animate(float duration, Action<float> callback) =>
-            new EaseEnumerator(EaseEnumerator(duration, callback));
+        public static AnimCoroutineHandler Animate(float duration, Action<float> callback) =>
+            new AnimCoroutineHandler(AnimateInner(duration, callback));
 
-        private static IEnumerator EaseEnumerator(float duration, Action<float> callback)
+        private static IEnumerator AnimateInner(float duration, Action<float> callback)
         {
-            var handler = EaseEnumerator.Current;
+            var handler = AnimCoroutineHandler.Current;
             for (float a = 0; a < 1; a += Time.deltaTime / duration)
             {
                 if (handler.CancelRequested)
@@ -188,12 +234,12 @@ namespace JANOARG.Shared.Data.ChartInfo
         /// <param name="mode">Easing mode (In/Out/InOut)</param>
         /// <param name="callback">Action receiving (progress, easeFunc, mode) each frame</param>
         /// <returns>An AnimCoroutineHandler that can be passed to StartCoroutine and used to Skip individually.</returns>
-        public static EaseEnumerator Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode> callback) =>
-            new EaseEnumerator(EaseEnumerator(duration, easeFunc, mode, callback));
+        public static AnimCoroutineHandler Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode> callback) =>
+            new AnimCoroutineHandler(AnimateInner(duration, easeFunc, mode, callback));
 
-        private static IEnumerator EaseEnumerator(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode> callback)
+        private static IEnumerator AnimateInner(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode> callback)
         {
-            var handler = EaseEnumerator.Current;
+            var handler = AnimCoroutineHandler.Current;
             for (float a = 0; a < 1; a += Time.deltaTime / duration)
             {
                 if (handler.CancelRequested)
@@ -218,12 +264,12 @@ namespace JANOARG.Shared.Data.ChartInfo
         /// <param name="mode">Easing mode (In/Out/InOut)</param>
         /// <param name="callback">Action receiving (progress, easeFunc, mode, easedValue) each frame</param>
         /// <returns>An AnimCoroutineHandler that can be passed to StartCoroutine and used to Skip individually.</returns>
-        public static EaseEnumerator Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode, float> callback) =>
-            new EaseEnumerator(EaseEnumerator(duration, easeFunc, mode, callback));
+        public static AnimCoroutineHandler Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode, float> callback) =>
+            new AnimCoroutineHandler(AnimateInner(duration, easeFunc, mode, callback));
 
-        private static IEnumerator EaseEnumerator(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode, float> callback)
+        private static IEnumerator AnimateInner(float duration, EaseFunction easeFunc, EaseMode mode, Action<float, EaseFunction, EaseMode, float> callback)
         {
-            var handler = EaseEnumerator.Current;
+            var handler = AnimCoroutineHandler.Current;
             float ease;
             for (float a = 0; a < 1; a += Time.deltaTime / duration)
             {
@@ -251,12 +297,12 @@ namespace JANOARG.Shared.Data.ChartInfo
         /// <param name="mode">Easing mode (In/Out/InOut)</param>
         /// <param name="callback">Action receiving eased progress value (0 to 1) each frame</param>
         /// <returns>An AnimCoroutineHandler that can be passed to StartCoroutine and used to Skip individually.</returns>
-        public static EaseEnumerator Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float> callback) =>
-            new EaseEnumerator(EaseEnumerator(duration, easeFunc, mode, callback));
+        public static AnimCoroutineHandler Animate(float duration, EaseFunction easeFunc, EaseMode mode, Action<float> callback) =>
+            new AnimCoroutineHandler(AnimateInner(duration, easeFunc, mode, callback));
 
-        private static IEnumerator EaseEnumerator(float duration, EaseFunction easeFunc, EaseMode mode, Action<float> callback)
+        private static IEnumerator AnimateInner(float duration, EaseFunction easeFunc, EaseMode mode, Action<float> callback)
         {
-            var handler = EaseEnumerator.Current;
+            var handler = AnimCoroutineHandler.Current;
             float ease;
             for (float a = 0; a < 1; a += Time.deltaTime / duration)
             {
@@ -965,13 +1011,13 @@ namespace JANOARG.Shared.Data.ChartInfo
     /// Warning: if Unity's StopCoroutine is called externally, IsComplete will not update automatically.
     /// Call anim.Complete() manually after StopCoroutine to keep state consistent.
     /// </summary>
-    public class EaseEnumerator : IEnumerator
+    public class AnimCoroutineHandler : IEnumerator
     {
-        internal static readonly List<WeakReference<EaseEnumerator>> s_active = new();
+        internal static readonly List<WeakReference<AnimCoroutineHandler>> s_active = new();
 
-        // ThreadStatic so EaseEnumerator can retrieve its own handler during construction
+        // ThreadStatic so AnimateInner can retrieve its own handler during construction
         [ThreadStatic]
-        internal static EaseEnumerator Current;
+        internal static AnimCoroutineHandler Current;
 
         private readonly IEnumerator _inner;
 
@@ -983,10 +1029,10 @@ namespace JANOARG.Shared.Data.ChartInfo
 
         object IEnumerator.Current => _inner.Current;
 
-        internal EaseEnumerator(IEnumerator inner)
+        internal AnimCoroutineHandler(IEnumerator inner)
         {
             _inner = inner;
-            s_active.Add(new WeakReference<EaseEnumerator>(this));
+            s_active.Add(new WeakReference<AnimCoroutineHandler>(this));
         }
 
         /// <summary>
@@ -1017,7 +1063,7 @@ namespace JANOARG.Shared.Data.ChartInfo
 
         public bool MoveNext()
         {
-            // Set Current so EaseEnumerator can retrieve its handler via AnimCoroutineHandler.Current
+            // Set Current so AnimateInner can retrieve its handler via AnimCoroutineHandler.Current
             Current = this;
             bool hasNext = _inner.MoveNext();
             Current = null;


### PR DESCRIPTION
This involves pushing constants to a higher scope to reduce duplicate constant allocation, using approximation optimised for 0-1 floats instead of Mathf functions to reduce external call overhead.

Also Task-based alternative methods are introduced to give options to move away from Unity Coroutine/IEnumerator, as well as extra methods that allow for further abstractions by not having to copy the main easing mode and functions repeatedly.